### PR TITLE
Update GuzzleHttp/guzzle dependency from ^6.5 to ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "guzzlehttp/guzzle": "^6.5",
+        "guzzlehttp/guzzle": "^7.0",
         "illuminate/notifications": "~5.5 || ~6.0 || ~7.0",
         "illuminate/support": "~5.5 || ~6.0 || ~7.0"
     },


### PR DESCRIPTION
Hello i'm using a package in laravel that exports data to excel spreadsheets and it also has a dependency of guzzleHtpp but its locked to version 7 so I'm obliged to update the depency of your package.

Thank you for your work :D