### PR TITLE
Update guzzle support to 6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "guzzlehttp/guzzle": "^6.5 || ^7.0",
+        "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "illuminate/notifications": "~5.5 || ~6.0 || ~7.0",
         "illuminate/support": "~5.5 || ~6.0 || ~7.0"
     },


### PR DESCRIPTION
Laravel 5.5 could be used along with Laravel Passport version 4, which has a dependency of guzzle 6.3, and therefore it prevents installing the use of the Teams notification channel. Supporting guzzle 6.3 does not seem to have any inconsistencies.