### PR TITLE
Check if message is an MicrosoftTeamsMessage instance

### DIFF
--- a/src/MicrosoftTeamsChannel.php
+++ b/src/MicrosoftTeamsChannel.php
@@ -33,6 +33,10 @@ class MicrosoftTeamsChannel
     {
         $message = $notification->toMicrosoftTeams($notifiable);
 
+        if (! $message instanceof MicrosoftTeamsMessage) {
+            return;
+        }
+
         // if the recipient is not defined get it from the notifiable object
         if ($message->toNotGiven()) {
             $to = $notifiable->routeNotificationFor('microsoftTeams', $notification);


### PR DESCRIPTION
In a similar way as `MailChannel` check if the message is an instance of `Mailable`, I would like to introduce a check to ensure that the message is an instance of `MicrosoftTeamsMessage`.

This is useful in the case we want to send the notification on condition and `$message` is `null`:
```php
    public function toMicrosoftTeams($notifiable)
    {
        if (...some condition...) {
            // Do not send notification
            return;
        }

        return MicrosoftTeamsMessage::create()
            ...
        ;
    }
```

See MailChannel code here:
https://github.com/laravel/framework/blob/eb66928b4aaa3fa84bdd95db44d27fc7e0977563/src/Illuminate/Notifications/Channels/MailChannel.php#L57-L60