### PR TITLE
 Feature: Add fullWidth() option for Adaptive Card display

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Notification::route(MicrosoftTeamsChannel::class,null)
 -   `create()`: Static factory method to create a new instance of the MicrosoftTeamsAdaptiveCard.
 -   `to(string $webhookUrl)`: Sets the recipient's webhook URL. Required for sending notifications.
 -   `title(string $title)`: Sets the title of the adaptive card with appropriate text styling (heading style, bold weight, and large size).
+-   `fullWidth()`: Sets the adaptive card to take up the full width of the Teams channel or chat instead of the default width.
 -   `content(array $contentBlocks)`: Adds content blocks to the adaptive card body. Accepts an array of content block objects like TextBlock, FactSet, Icon, etc.
 -   `actions(array $actions)`: Adds action buttons to the adaptive card. Accepts an array of action objects like ActionOpenUrl.
 -   `getWebhookUrl()`: Returns the currently set webhook URL.

--- a/src/MicrosoftTeamsAdaptiveCard.php
+++ b/src/MicrosoftTeamsAdaptiveCard.php
@@ -83,6 +83,18 @@ class MicrosoftTeamsAdaptiveCard
     }
 
     /**
+     * Sets the card to take the full width
+     *
+     * @return MicrosoftTeamsAdaptiveCard $this
+     */
+    public function fullWidth(): self
+    {
+        $this->payload['attachments'][0]['content']['msteams']['width'] = 'Full';
+
+        return $this;
+    }
+
+    /**
      * Get webhook url.
      *
      * @return string $webhookUrl

--- a/tests/MicrosoftTeamsAdaptiveCardTest.php
+++ b/tests/MicrosoftTeamsAdaptiveCardTest.php
@@ -328,4 +328,17 @@ class MicrosoftTeamsAdaptiveCardTest extends TestCase
 
         $this->assertEquals($expectedPayload, $card->toArray());
     }
+
+    /** @test */
+    public function full_width_can_be_set(): void
+    {
+        $card = new MicrosoftTeamsAdaptiveCard();
+
+        $card->fullWidth();
+
+        $payload = $card->toArray();
+        $cardWidth = $payload['attachments'][0]['content']['msteams']['width'];
+
+        $this->assertEquals('Full', $cardWidth);
+    }
 }


### PR DESCRIPTION
Related to #37

This PR introduces a new fullWidth() method on the MicrosoftTeamsAdaptiveCard class, allowing Adaptive Cards to be displayed at full width in Microsoft Teams.

After reading the Microsoft Adaptive Card documentation, 'Full' appears to be the only supported value for the msteams.width field. The msteams field also can't be empty.

I decided to let the fullWidth() method handles payload configuration so developers don't have to manage Teams-specific structure manually.

This is my first contribution, so please let me know if anything should be improved or adjusted!