### PR TITLE
Remove static from closures for Laravel 13 compatibility

### DIFF
--- a/src/MicrosoftTeamsServiceProvider.php
+++ b/src/MicrosoftTeamsServiceProvider.php
@@ -18,7 +18,7 @@ class MicrosoftTeamsServiceProvider extends ServiceProvider
 
         $this->app->when(MicrosoftTeamsChannel::class)
             ->needs(MicrosoftTeams::class)
-            ->give(static function () {
+            ->give(function () {
                 return new MicrosoftTeams(
                     new HttpClient
                 );
@@ -30,7 +30,7 @@ class MicrosoftTeamsServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        Notification::extend('microsoftTeams', static function (Container $app) {
+        Notification::extend('microsoftTeams', function (Container $app) {
             return $app->make(MicrosoftTeamsChannel::class);
         });
     }


### PR DESCRIPTION
## Summary

Laravel 13 changed `Manager::extend()` to bind closures to the manager instance via `$callback->bindTo($this, $this)`. Since PHP does not allow binding an instance to a static closure, this causes a fatal error:

```
Cannot bind an instance to a static closure
```

This PR removes the `static` keyword from the two closures in `MicrosoftTeamsServiceProvider`:

- The `->give()` closure on line 21
- The `Notification::extend()` closure on line 33

Neither closure relies on `static` for correctness (they don't reference `$this`), so removing it is a safe, backwards-compatible change that fixes Laravel 13 support.